### PR TITLE
Clarify help for `arg_many()` and `arg_many1()`

### DIFF
--- a/examples/many-opts/README.md
+++ b/examples/many-opts/README.md
@@ -8,12 +8,12 @@ many-opts -- Provide many options
 
 Usage:
 
-  many-opts [OPTIONS] NEXT REST...
+  many-opts [OPTIONS] NEXT [REST...]
 
 Arguments:
 
   NEXT                  Next
-  REST...               Rest (zero or more)
+  [REST...]             Rest (zero or more)
 
 Options:
 

--- a/src/clip/internal/arg_info.gleam
+++ b/src/clip/internal/arg_info.gleam
@@ -68,7 +68,8 @@ fn pos_str(p_info: PositionalInfo) -> String {
   let name = string.uppercase(p_info.name)
   let name = case p_info.repeat {
     NoRepeat -> name
-    _ -> name <> "..."
+    ManyRepeat -> "[" <> name <> "...]"
+    Many1Repeat -> name <> "..."
   }
   name
 }


### PR DESCRIPTION
When displaying help the usage for both `arg_many()` and `arg_many1()` was rendered as `ARG...`.  However, `...` is commonly used to mean "one or more":

- [POSIX.1-2024 12.1.9](https://pubs.opengroup.org/onlinepubs/9799919799/basedefs/V1_chap12.html#tag_12_01)
- [docopt](http://docopt.org/)

Hence for rendering `arg_many()`'s usage of "zero or more" something like `[ARG...]` or `[ARG]...` should be used.  This would be in line with various manual pages of `cat`, for example:

- [GNU cat](https://www.gnu.org/software/coreutils/manual/html_node/cat-invocation.html)
- [FreeBSD cat](https://man.freebsd.org/cgi/man.cgi?query=cat)
- [illumos cat](https://illumos.org/man/1/cat)
- [POSIX cat](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/cat.html)

The usage of `arg_many()` is now rendered as `[ARG...]` while `arg_many1()` remains as `ARG...`.